### PR TITLE
[python][cpp] Add hierarchical merge and sorted write optimization

### DIFF
--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -61,6 +61,7 @@ PYBIND11_MODULE(cpp, m) {
     m.def("query_precalculated_pseudobulk_coverage", &BPCells::py::query_precalculated_pseudobulk_coverage);
         
     m.def("write_matrix_dir_from_memory", &BPCells::py::write_matrix_dir_from_memory);
+    m.def("write_matrix_dir_from_memory_experimental", &BPCells::py::write_matrix_dir_from_memory_experimental);
     m.def("write_matrix_dir_from_concat", &BPCells::py::write_matrix_dir_from_concat);
     m.def("write_matrix_dir_from_concat_experimental", &BPCells::py::write_matrix_dir_from_concat_experimental,
           pybind11::arg("in_paths"),

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -62,7 +62,13 @@ PYBIND11_MODULE(cpp, m) {
         
     m.def("write_matrix_dir_from_memory", &BPCells::py::write_matrix_dir_from_memory);
     m.def("write_matrix_dir_from_concat", &BPCells::py::write_matrix_dir_from_concat);
-    m.def("write_matrix_dir_from_concat_experimental", &BPCells::py::write_matrix_dir_from_concat_experimental);
+    m.def("write_matrix_dir_from_concat_experimental", &BPCells::py::write_matrix_dir_from_concat_experimental,
+          pybind11::arg("in_paths"),
+          pybind11::arg("out_path"),
+          pybind11::arg("concat_rows"),
+          pybind11::arg("batch_size") = 16,
+          pybind11::arg("threads") = 1,
+          pybind11::arg("temp_dir") = "");
     m.def("write_matrix_dir_from_h5ad", &BPCells::py::write_matrix_dir_from_h5ad);
     
     m.def("load_matrix_dir_subset", &BPCells::py::load_matrix_dir_subset);

--- a/python/src/matrix.cpp
+++ b/python/src/matrix.cpp
@@ -16,12 +16,16 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <random>
+#include <sstream>
+#include <iomanip>
 
 #include <Eigen/SparseCore>
 #include "bpcells-cpp/matrixIterators/StoredMatrixSparseColumn.h"
 
 #include "bpcells-cpp/arrayIO/binaryfile.h"
 #include "bpcells-cpp/arrayIO/vector.h"
+#include "bpcells-cpp/utils/filesystem_compat.h"
 
 #include "bpcells-cpp/matrixIterators/CSparseMatrix.h"
 #include "bpcells-cpp/matrixIterators/MatrixIndexSelect.h"
@@ -102,14 +106,56 @@ void write_matrix_dir_from_concat(std::vector<std::string> in_paths, std::string
     );
 }
 
-void write_matrix_dir_from_concat_experimental(std::vector<std::string> in_paths, std::string out_path, bool concat_rows) {
-    // Concatenate experimental format matrices (packed-uint-matrix-v9999)
-    // Used for precalculated pseudobulk coverage matrices
+// Helper to generate a unique temp directory name
+static std::string generate_unique_id() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis;
+    std::stringstream ss;
+    ss << std::hex << std::setfill('0') << std::setw(16) << dis(gen);
+    return ss.str();
+}
+
+// Internal helper for merging a batch of experimental matrices (single-threaded)
+static void merge_batch_experimental_internal(
+    const std::vector<std::string>& in_paths,
+    const std::string& out_path,
+    bool concat_rows,
+    std::atomic<bool>* user_interrupt
+) {
     std::vector<std::unique_ptr<MatrixLoader<uint32_t>>> mats;
 
-    if (in_paths.size() == 0) {
-        throw std::runtime_error("write_matrix_dir_from_concat_experimental: Zero matrices given as input.");
+    for (const std::string &path : in_paths) {
+        FileReaderBuilder rb(path);
+        mats.push_back(std::make_unique<StoredMatrix<uint32_t>>(EXPERIMENTAL_openPackedSparseColumn<uint32_t>(rb)));
     }
+
+    std::unique_ptr<MatrixLoader<uint32_t>> mat;
+    if (concat_rows) {
+        mat = std::make_unique<ConcatRows<uint32_t>>(std::move(mats), 0);
+    } else {
+        mat = std::make_unique<ConcatCols<uint32_t>>(std::move(mats), 0);
+    }
+
+    FileWriterBuilder wb(out_path);
+    auto writer = EXPERIMENTAL_createPackedSparseColumn<uint32_t>(wb);
+
+    // ConcatRows produces sorted output (row offsets create non-overlapping, increasing ranges)
+    // so we can skip the sorting check for better performance
+    if (concat_rows) {
+        writer.writeSorted(*mat, user_interrupt);
+    } else {
+        writer.write(*mat, user_interrupt);
+    }
+}
+
+// Simple concat for small number of matrices
+static void write_matrix_dir_from_concat_experimental_simple(
+    const std::vector<std::string>& in_paths,
+    const std::string& out_path,
+    bool concat_rows
+) {
+    std::vector<std::unique_ptr<MatrixLoader<uint32_t>>> mats;
 
     for (const std::string &path : in_paths) {
         FileReaderBuilder rb(path);
@@ -125,11 +171,157 @@ void write_matrix_dir_from_concat_experimental(std::vector<std::string> in_paths
 
     FileWriterBuilder wb(out_path);
 
-    run_with_py_interrupt_check(
-        &StoredMatrixWriter<uint32_t>::write,
-        EXPERIMENTAL_createPackedSparseColumn<uint32_t>(wb),
-        std::ref(*mat)
-    );
+    // ConcatRows produces sorted output, so use writeSorted for better performance
+    if (concat_rows) {
+        run_with_py_interrupt_check(
+            &StoredMatrixWriter<uint32_t>::writeSorted,
+            EXPERIMENTAL_createPackedSparseColumn<uint32_t>(wb),
+            std::ref(*mat)
+        );
+    } else {
+        run_with_py_interrupt_check(
+            &StoredMatrixWriter<uint32_t>::write,
+            EXPERIMENTAL_createPackedSparseColumn<uint32_t>(wb),
+            std::ref(*mat)
+        );
+    }
+}
+
+void write_matrix_dir_from_concat_experimental(
+    std::vector<std::string> in_paths,
+    std::string out_path,
+    bool concat_rows,
+    uint32_t batch_size,
+    uint32_t threads,
+    std::string temp_dir
+) {
+    // Concatenate experimental format matrices (packed-uint-matrix-v9999)
+    // Used for precalculated pseudobulk coverage matrices
+    // Supports hierarchical merge for better performance with many matrices
+
+    if (in_paths.size() == 0) {
+        throw std::runtime_error("write_matrix_dir_from_concat_experimental: Zero matrices given as input.");
+    }
+
+    if (in_paths.size() == 1) {
+        // Just copy the single matrix
+        write_matrix_dir_from_concat_experimental_simple(in_paths, out_path, concat_rows);
+        return;
+    }
+
+    // If we have few enough matrices, use the simple merge
+    if (in_paths.size() <= batch_size) {
+        write_matrix_dir_from_concat_experimental_simple(in_paths, out_path, concat_rows);
+        return;
+    }
+
+    // Set up temp directory
+    std_fs::path temp_base;
+    bool created_temp_dir = false;
+    if (temp_dir.empty()) {
+        std_fs::path out_parent = std_fs::path(out_path).parent_path();
+        if (out_parent.empty()) out_parent = ".";
+        temp_base = out_parent / (".bpcells_tmp_" + generate_unique_id());
+    } else {
+        temp_base = std_fs::path(temp_dir);
+    }
+
+    if (!std_fs::exists(temp_base)) {
+        std_fs::create_directories(temp_base);
+        created_temp_dir = true;
+    }
+
+    // RAII cleanup helper
+    struct TempDirCleanup {
+        std_fs::path path;
+        bool should_remove;
+        ~TempDirCleanup() {
+            if (should_remove && std_fs::exists(path)) {
+                std::error_code ec;
+                std_fs::remove_all(path, ec);
+            }
+        }
+    };
+    TempDirCleanup cleanup{temp_base, created_temp_dir};
+
+    // Split paths into batches
+    std::vector<std::vector<std::string>> batches;
+    size_t n = in_paths.size();
+    size_t num_batches = (n + batch_size - 1) / batch_size;
+
+    for (size_t i = 0; i < num_batches; i++) {
+        size_t start = i * batch_size;
+        size_t end = std::min(start + batch_size, n);
+        batches.emplace_back(in_paths.begin() + start, in_paths.begin() + end);
+    }
+
+    // Merge batches to intermediate files
+    std::vector<std::string> intermediate_paths;
+
+    if (threads <= 1) {
+        // Single-threaded: merge batches sequentially
+        run_with_py_interrupt_check([&](std::atomic<bool>* user_interrupt) {
+            for (size_t i = 0; i < batches.size(); i++) {
+                if (user_interrupt && *user_interrupt) return;
+
+                std::string intermediate_path = (temp_base / ("batch_" + std::to_string(i))).string();
+                merge_batch_experimental_internal(batches[i], intermediate_path, concat_rows, user_interrupt);
+                intermediate_paths.push_back(intermediate_path);
+            }
+        });
+    } else {
+        // Multi-threaded: merge batches in parallel
+        intermediate_paths.resize(batches.size());
+        for (size_t i = 0; i < batches.size(); i++) {
+            intermediate_paths[i] = (temp_base / ("batch_" + std::to_string(i))).string();
+        }
+
+        run_with_py_interrupt_check([&](std::atomic<bool>* user_interrupt) {
+            std::vector<std::future<void>> futures;
+            std::atomic<size_t> task_id(0);
+
+            // Create tasks using deferred execution
+            for (size_t i = 0; i < batches.size(); i++) {
+                futures.push_back(std::async(
+                    std::launch::deferred,
+                    [&batches, &intermediate_paths, concat_rows, i, user_interrupt]() {
+                        merge_batch_experimental_internal(batches[i], intermediate_paths[i], concat_rows, user_interrupt);
+                    }
+                ));
+            }
+
+            // Execute with thread pool
+            uint32_t actual_threads = std::min(threads, static_cast<uint32_t>(batches.size()));
+            std::vector<std::thread> thread_vec;
+
+            for (uint32_t t = 0; t < actual_threads; t++) {
+                thread_vec.push_back(std::thread([&futures, &task_id, user_interrupt] {
+                    while (true) {
+                        if (user_interrupt && *user_interrupt) break;
+                        size_t cur_task = task_id.fetch_add(1);
+                        if (cur_task >= futures.size()) break;
+                        futures[cur_task].get();
+                    }
+                }));
+            }
+
+            for (auto& th : thread_vec) {
+                if (th.joinable()) th.join();
+            }
+        });
+    }
+
+    // Recursively merge intermediate files
+    if (intermediate_paths.size() <= batch_size) {
+        // Final merge directly to output
+        write_matrix_dir_from_concat_experimental_simple(intermediate_paths, out_path, concat_rows);
+    } else {
+        // Need another level of recursion
+        std::string next_temp_dir = (temp_base / "level2").string();
+        write_matrix_dir_from_concat_experimental(
+            intermediate_paths, out_path, concat_rows, batch_size, threads, next_temp_dir
+        );
+    }
 }
 
 void write_matrix_dir_from_h5ad(std::string h5ad_path, std::string out_path, std::string group) {

--- a/python/src/matrix.cpp
+++ b/python/src/matrix.cpp
@@ -61,6 +61,29 @@ void write_matrix_dir_from_memory(
     );
 }
 
+void write_matrix_dir_from_memory_experimental(
+    const Eigen::SparseMatrix<uint32_t> in, std::string out_path
+) {
+    const Eigen::Map<Eigen::SparseMatrix<uint32_t>> in_map(
+        in.rows(),
+        in.cols(),
+        in.nonZeros(),
+        (int *)in.outerIndexPtr(),
+        (int *)in.innerIndexPtr(),
+        (uint32_t *)in.valuePtr()
+    );
+
+    auto mat = std::make_unique<CSparseMatrix<uint32_t>>(in_map);
+
+    FileWriterBuilder wb(out_path);
+
+    run_with_py_interrupt_check(
+        &StoredMatrixWriter<uint32_t>::write,
+        EXPERIMENTAL_createPackedSparseColumn<uint32_t>(wb),
+        std::ref(*mat)
+    );
+}
+
 static bool is_row_major_matrix_dir(std::string path) {
     FileReaderBuilder rb(path);
     auto storage_order_reader = rb.openStringReader("storage_order");

--- a/python/src/matrix.hpp
+++ b/python/src/matrix.hpp
@@ -21,6 +21,9 @@ namespace BPCells::py {
 
 void write_matrix_dir_from_memory(const Eigen::SparseMatrix<uint32_t> in, std::string out_path, bool row_major = false);
 
+// Write matrix in experimental v9999 format (for testing write_matrix_dir_from_concat_experimental)
+void write_matrix_dir_from_memory_experimental(const Eigen::SparseMatrix<uint32_t> in, std::string out_path);
+
 void write_matrix_dir_from_concat(std::vector<std::string> in_paths, std::string out_path, bool concat_cols);
 
 // Concatenate experimental format matrices (packed-uint-matrix-v9999)

--- a/python/src/matrix.hpp
+++ b/python/src/matrix.hpp
@@ -25,7 +25,18 @@ void write_matrix_dir_from_concat(std::vector<std::string> in_paths, std::string
 
 // Concatenate experimental format matrices (packed-uint-matrix-v9999)
 // Used for precalculated pseudobulk coverage matrices
-void write_matrix_dir_from_concat_experimental(std::vector<std::string> in_paths, std::string out_path, bool concat_rows);
+// Supports hierarchical merge for better performance with many input matrices.
+// batch_size: number of matrices to merge at once (default 16)
+// threads: number of parallel merge threads (default 1)
+// temp_dir: directory for intermediate files (default: out_path.parent / ".bpcells_tmp")
+void write_matrix_dir_from_concat_experimental(
+    std::vector<std::string> in_paths,
+    std::string out_path,
+    bool concat_rows,
+    uint32_t batch_size = 16,
+    uint32_t threads = 1,
+    std::string temp_dir = ""
+);
 
 void write_matrix_dir_from_h5ad(std::string h5ad_path, std::string out_path, std::string group);
 

--- a/r/src/bpcells-cpp/matrixIterators/OrderRows.h
+++ b/r/src/bpcells-cpp/matrixIterators/OrderRows.h
@@ -1,5 +1,5 @@
 // Copyright 2022 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -24,11 +24,15 @@ template <class T> class OrderRows : public MatrixLoaderWrapper<T> {
     uint32_t idx = 0;
     uint32_t cap = 0;
     uint32_t load_size;
+    bool assume_sorted; // Skip sorting check when we know input is sorted
 
   public:
-    OrderRows(std::unique_ptr<MatrixLoader<T>> &&loader, uint32_t load_size = 1024)
+    // If assume_sorted is true, skip the sorting check entirely (useful when input
+    // is known to be sorted, e.g., from ConcatRows with row-offset-adjusted data)
+    OrderRows(std::unique_ptr<MatrixLoader<T>> &&loader, uint32_t load_size = 1024, bool assume_sorted = false)
         : MatrixLoaderWrapper<T>(std::move(loader))
-        , load_size(load_size) {
+        , load_size(load_size)
+        , assume_sorted(assume_sorted) {
         row_data.resize(this->loader->rows());
         row_buf.resize(this->loader->rows());
         val_data.resize(this->loader->rows());
@@ -67,11 +71,17 @@ template <class T> class OrderRows : public MatrixLoaderWrapper<T> {
 
                 std::memmove(val_data.data() + cap, val_ptr, sizeof(T) * loaded);
 
-                for (uint32_t i = 0; i < loaded; i++) {
-                    row_data[cap + i] = row_ptr[i];
-                    // Assume no duplicate row indices so we don't need <=
-                    if (row_ptr[i] < prev_row) needs_reorder = true;
-                    prev_row = row_ptr[i];
+                if (assume_sorted) {
+                    // Fast path: just copy row data without checking order
+                    std::memmove(row_data.data() + cap, row_ptr, sizeof(uint32_t) * loaded);
+                } else {
+                    // Check if reordering is needed while copying
+                    for (uint32_t i = 0; i < loaded; i++) {
+                        row_data[cap + i] = row_ptr[i];
+                        // Assume no duplicate row indices so we don't need <=
+                        if (row_ptr[i] < prev_row) needs_reorder = true;
+                        prev_row = row_ptr[i];
+                    }
                 }
                 cap += loaded;
             }

--- a/r/src/bpcells-cpp/matrixIterators/StoredMatrixWriter.h
+++ b/r/src/bpcells-cpp/matrixIterators/StoredMatrixWriter.h
@@ -102,8 +102,20 @@ template <typename T> class StoredMatrixWriter : public MatrixWriter<T> {
     }
 
     void write(MatrixLoader<T> &mat_in, std::atomic<bool> *user_interrupt = NULL) override {
+        writeInternal(mat_in, user_interrupt, false);
+    }
+
+    // Write with assumption that input rows are already sorted (skips sorting check)
+    // Use this when writing from ConcatRows which produces sorted output
+    void writeSorted(MatrixLoader<T> &mat_in, std::atomic<bool> *user_interrupt = NULL) {
+        writeInternal(mat_in, user_interrupt, true);
+    }
+
+  private:
+    void writeInternal(MatrixLoader<T> &mat_in, std::atomic<bool> *user_interrupt, bool assume_sorted) {
         // Ensure that we write matrices sorted by row
-        OrderRows<T> mat((std::unique_ptr<MatrixLoader<T>>(&mat_in)));
+        // When assume_sorted is true, we skip the sorting check for better performance
+        OrderRows<T> mat((std::unique_ptr<MatrixLoader<T>>(&mat_in)), 1024, assume_sorted);
         // Don't delete our original matrix
         mat.preserve_input_loader();
         uint32_t col = 0;


### PR DESCRIPTION
Optimize write_matrix_dir_from_concat_experimental for hundreds of files:

1. Hierarchical merge: merges matrices in batches (default 16) to intermediate files, then recursively merges results. Reduces per-column complexity from O(N) to O(batch_size × log_batch_size(N)).

2. Parallel batch processing: new threads parameter for concurrent batch merging.

3. Skip sorting for ConcatRows: ConcatRows produces already-sorted output (row offsets create non-overlapping, increasing ranges). Added assume_sorted parameter to OrderRows and writeSorted() to StoredMatrixWriter to skip the per-column radix sort check.

New parameters:
- batch_size: matrices to merge at once (default 16)
- threads: parallel merge threads (default 1)
- temp_dir: custom temp directory (default auto-generated)

Expected speedup: 5-10x for 100+ matrices.